### PR TITLE
add exponential backoff/retry for state DB get

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 click-option-group>=0.5.5
 cirrus-geo>=0.9.0
+backoff>=2.2.1

--- a/src/cirrus/plugins/management/deployment.py
+++ b/src/cirrus/plugins/management/deployment.py
@@ -213,7 +213,9 @@ class Deployment(DeploymentMeta):
             session=self.get_session(),
         )
 
-        @backoff.on_exception(backoff.expo, PayloadNotFoundError, max_time=60)
+        @backoff.on_exception(
+            backoff.expo, exceptions.PayloadNotFoundError, max_time=60
+        )
         def _get_payload_item_from_statedb(statedb, payload_id):
             return statedb.get_dbitem(payload_id)
 

--- a/src/cirrus/plugins/management/deployment.py
+++ b/src/cirrus/plugins/management/deployment.py
@@ -213,8 +213,8 @@ class Deployment(DeploymentMeta):
             session=self.get_session(),
         )
 
-        @backoff.on_exception(
-            backoff.expo, exceptions.PayloadNotFoundError, max_time=60
+        @backoff.on_predicate(
+            backoff.expo, lambda x: x is None, max_time=60
         )
         def _get_payload_item_from_statedb(statedb, payload_id):
             return statedb.get_dbitem(payload_id)

--- a/src/cirrus/plugins/management/deployment.py
+++ b/src/cirrus/plugins/management/deployment.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from pprint import pprint
 from subprocess import check_call
 from time import sleep, time, time_ns
+import backoff
 
 from cirrus.lib2.process_payload import ProcessPayload
 

--- a/src/cirrus/plugins/management/deployment.py
+++ b/src/cirrus/plugins/management/deployment.py
@@ -211,7 +211,13 @@ class Deployment(DeploymentMeta):
             table_name=self.environment["CIRRUS_STATE_DB"],
             session=self.get_session(),
         )
-        state = statedb.get_dbitem(payload_id)
+
+        @backoff.on_exception(backoff.expo, PayloadNotFoundError, max_time=60)
+        def _get_payload_item_from_statedb(statedb, payload_id):
+            return statedb.get_dbitem(payload_id)
+
+        state = _get_payload_item_from_statedb(statedb, payload_id)
+
         if not state:
             raise exceptions.PayloadNotFoundError(payload_id)
         return state


### PR DESCRIPTION
Due to intermittent race-condition problem when `get`ing from the state DB, add an exponential backoff.